### PR TITLE
Allows user to specify search terms and adds Album art from Last.fm

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ Download your spotify playlists using simple python script
 * Convert your spotify playlists to csv from [here](http://joellehman.com/playlist/) (Thanks to [Joel Lehman](https://github.com/jal278))
 * Use [download_from_csv.py](download_from_csv.py) to download all songs from the playlist. (For usage: `python download_from_csv.py -h`)
 
+### Note
+* If you build your own packages, then make sure to build FFmpeg (that youtube-dl uses) using the '--enable-libmp3lame' option
 
 ### TODO
 I am planning to add more features to this to make the experience more smooth and improve the quality of the downloaded songs. Feel free to open an issue for any bug or enhancement that
 
 - [ ] Allow exporting to CSV from the script itself, will need to ask for spotify login
-- [ ] Allow user to specify search terms for youtube (either through config file or through command line arguments)
+- [x] Allow user to specify search terms for youtube (either through config file or through command line arguments)
 - [ ] Add Album Art to the downloaded songs

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ I am planning to add more features to this to make the experience more smooth an
 
 - [ ] Allow exporting to CSV from the script itself, will need to ask for spotify login
 - [x] Allow user to specify search terms for youtube (either through config file or through command line arguments)
-- [ ] Add Album Art to the downloaded songs
+- [x] Add Album Art to the downloaded songs

--- a/album_art.py
+++ b/album_art.py
@@ -1,22 +1,26 @@
 import requests
 import os
-import string
 import json
 from bs4 import BeautifulSoup
 
+
 def fetch(song, **kwargs):
-    if kwargs['backend'] == 'lastfm':
+    if kwargs.get('backend', None) == 'lastfm':
         image = fetch_from_lastfm(song)
-    elif kwargs['backend'] == 'google':
+        if image:
+            print 'Downloaded image from Lastfm'
+    else:
         image = fetch_from_google(song)
+        if image:
+            print 'Downloaded image from Google'
     return image
+
 
 def fetch_from_google(song):
     ''' Downloads art from images.google.com '''
 
-    query = song['artist'] + song['name'] + 'cover art google play' # Art work can be of huge size so the 'google play' in query mostly results into smaller images
-    query = string.replace(query, ' ', '+')
-    url = 'https://www.google.com/search?site=&tbm=isch&source=hp&biw=1366&bih=649&q=%s&oq=%s&gs_l=img.3...857.12029.0.12205.36.14.1.20.21.0.301.1337.0j7j0j1.8.0....0...1ac.1.64.img..7.15.1346.0..0j0i24k1.22gw0wRgCfk'%(query, query)
+    query = '+'.join([song['name'], song['artist'], 'cover', 'art'])
+    url = 'https://www.google.co.in/search?tbm=isch&q=%s' % query
     header = {
         'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11',
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
@@ -27,58 +31,53 @@ def fetch_from_google(song):
 
     response = requests.get(url, headers=header)
     soup = BeautifulSoup(response.content, 'html.parser')
-    tag = soup.find('div', {'class': 'rg_meta'})    #The first result
-    dictionary = json.loads(tag.string)
-    link = dictionary.get('ou', None)
-    if link == None:
-        print 'No link found'
-        return
-    image_download = link.decode('unicode-escape')
-    #print 'Image download link is %s' %image_download
+    tag = soup.find('div', {'class': 'rg_meta'})  # The first result
     try:
-        image = requests.get(image_download).content
-        return image
+        dictionary = json.loads(tag.string)
+    except AttributeError, e:
+        print e
+        return
+    image_download_link = dictionary.get('ou', None)
+    try:
+        image_download_link = image_download_link.decode('unicode-escape')
+        image = download_image_from_link(image_download_link)
     except:
-        print 'Could not download image'
+        print 'No link found'
+    return image
+
 
 def fetch_from_lastfm(song):
     ''' Downloads art from last.fm '''
 
     artist = song['artist']
     album = song['album']
-    track = song['name']
-    #Last.fm
     API_KEY = os.environ.get('LASTFM_API_KEY', None)
-    if API_KEY == None:
-        print 'You need to add an environment variable for LASTFM_API_KEY\n'
+    if API_KEY is None:
+        print 'You need to add an environment variable for LASTFM_API_KEY'
         return
-    url = 'http://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=%s&artist=%s&album=%s&format=json'%(API_KEY,artist,album)
+    url = 'http://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=%s&artist=%s&album=%s&format=json' % (API_KEY, artist, album)
     response = requests.get(url).json()
-    image_download = ''
-    images = []
+    album_dict = response.get('album', None)
     try:
-        images = response.get('album', None).get('image', None)
+        images = album_dict.get('image', None)
     except:
         print 'No images found for this album/track'
         return
     for image in reversed(images):
-        if image.get('size') == 'extralarge':       #The most suitable image size
-            image_download = image.get('#text')
+        current_size = image.get('size')
+        if current_size != 'mega' and current_size != '':   # There is also a size with value "" in the response JSON
+            image_download_link = image.get('#text', None)
             break
-        elif image.get('size') == 'large':
-            image_download = image.get('#text')
-            break
-        elif image.get('size') == 'medium':
-            image_download = image.get('#text')
-            break
-        elif image.get('size') == 'small':
-            image_download = image.get('#text')
-            break
-    if image_download == '':
-        return
     try:
-        image = requests.get(image_download).content
+        image = download_image_from_link(image_download_link)
+    except:
+        print 'No link found'
+    return image
+
+
+def download_image_from_link(url):
+    try:
+        image = requests.get(url).content
         return image
     except:
         print 'Could not download image'
-

--- a/album_art.py
+++ b/album_art.py
@@ -1,0 +1,84 @@
+import requests
+import os
+import string
+import json
+from bs4 import BeautifulSoup
+
+def fetch(song, **kwargs):
+    if kwargs['backend'] == 'lastfm':
+        image = fetch_from_lastfm(song)
+    elif kwargs['backend'] == 'google':
+        image = fetch_from_google(song)
+    return image
+
+def fetch_from_google(song):
+    ''' Downloads art from images.google.com '''
+
+    query = song['artist'] + song['name'] + 'cover art google play' # Art work can be of huge size so the 'google play' in query mostly results into smaller images
+    query = string.replace(query, ' ', '+')
+    url = 'https://www.google.com/search?site=&tbm=isch&source=hp&biw=1366&bih=649&q=%s&oq=%s&gs_l=img.3...857.12029.0.12205.36.14.1.20.21.0.301.1337.0j7j0j1.8.0....0...1ac.1.64.img..7.15.1346.0..0j0i24k1.22gw0wRgCfk'%(query, query)
+    header = {
+        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
+        'Accept-Encoding': 'none',
+        'Accept-Language': 'en-US,en;q=0.8',
+        'Connection': 'keep-alive'}
+
+    response = requests.get(url, headers=header)
+    soup = BeautifulSoup(response.content, 'html.parser')
+    tag = soup.find('div', {'class': 'rg_meta'})    #The first result
+    dictionary = json.loads(tag.string)
+    link = dictionary.get('ou', None)
+    if link == None:
+        print 'No link found'
+        return
+    image_download = link.decode('unicode-escape')
+    #print 'Image download link is %s' %image_download
+    try:
+        image = requests.get(image_download).content
+        return image
+    except:
+        print 'Could not download image'
+
+def fetch_from_lastfm(song):
+    ''' Downloads art from last.fm '''
+
+    artist = song['artist']
+    album = song['album']
+    track = song['name']
+    #Last.fm
+    API_KEY = os.environ.get('LASTFM_API_KEY', None)
+    if API_KEY == None:
+        print 'You need to add an environment variable for LASTFM_API_KEY\n'
+        return
+    url = 'http://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=%s&artist=%s&album=%s&format=json'%(API_KEY,artist,album)
+    response = requests.get(url).json()
+    image_download = ''
+    images = []
+    try:
+        images = response.get('album', None).get('image', None)
+    except:
+        print 'No images found for this album/track'
+        return
+    for image in reversed(images):
+        if image.get('size') == 'extralarge':       #The most suitable image size
+            image_download = image.get('#text')
+            break
+        elif image.get('size') == 'large':
+            image_download = image.get('#text')
+            break
+        elif image.get('size') == 'medium':
+            image_download = image.get('#text')
+            break
+        elif image.get('size') == 'small':
+            image_download = image.get('#text')
+            break
+    if image_download == '':
+        return
+    try:
+        image = requests.get(image_download).content
+        return image
+    except:
+        print 'Could not download image'
+

--- a/download_from_csv.py
+++ b/download_from_csv.py
@@ -14,7 +14,6 @@ import youtube_dl
 import json
 import album_art
 from unidecode import unidecode
-from urllib import urlopen, urlretrieve
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-f', '--folder', help="keep the files in the folder specified")

--- a/download_from_csv.py
+++ b/download_from_csv.py
@@ -101,25 +101,17 @@ for song in songs:
         'logger': MyLogger(),
         'outtmpl': folder + '/' + song['name'] + ' - ' + song['artist'] + '.%(ext)s'
     }
-    if args.query == None:
-        url = ' '.join([song['name'], song['artist'], 'audio', 'youtube'])
+    base_query = ' '.join(song['name'] + song['artist'])
+    if args.query is None:
+        url = '%s %s' % (base_query, 'audio youtube')
     else:
-        url = ' '.join([song['name'], song['artist']]) + ' '
-        url += args.query
+        url = '%s %s' % (base_query, args.query)
     url = 'gvsearch1:' + url
     print '[\033[91mFetching\033[00m] %s' % probable_filename
     with youtube_dl.YoutubeDL(opts) as ydl:
         ydl.download([url])
 
-    image = None
-    if args.art == None:
-        image = album_art.fetch(song, backend='google')
-        if image != None:
-            print 'Downloaded image from Google'
-    else:
-        image = album_art.fetch(song, backend=args.art)
-        if image != None:
-            print 'Downloaded image from %s' %args.art
+    image = album_art.fetch(song, backend=args.art)
     if os.path.isfile(probable_filename):
         afile = eyed3.load(probable_filename)
         afile.tag.title = unicode(song['name'], "utf-8")

--- a/download_from_csv.py
+++ b/download_from_csv.py
@@ -106,7 +106,6 @@ for song in songs:
     else:
         url = '%s %s' % (base_query, args.query)
     url = 'gvsearch1:' + url
-    print 'URL = %s' % url
     print '[\033[91mFetching\033[00m] %s' % probable_filename
     with youtube_dl.YoutubeDL(opts) as ydl:
         ydl.download([url])

--- a/download_from_csv.py
+++ b/download_from_csv.py
@@ -11,7 +11,6 @@ import csv
 import eyed3
 import argparse
 import youtube_dl
-import json
 import album_art
 from unidecode import unidecode
 
@@ -103,10 +102,11 @@ for song in songs:
     }
     base_query = ' '.join(song['name'] + song['artist'])
     if args.query is None:
-        url = '%s %s' % (base_query, 'audio youtube')
+        url = '%s %s' % (base_query, 'youtube')
     else:
         url = '%s %s' % (base_query, args.query)
     url = 'gvsearch1:' + url
+    print 'URL = %s' % url
     print '[\033[91mFetching\033[00m] %s' % probable_filename
     with youtube_dl.YoutubeDL(opts) as ydl:
         ydl.download([url])


### PR DESCRIPTION
The current Album Art backend is Google (default) and Last.fm which is available to the user by selecting an optional argument ~~which although works fine is not enough. Hence it is WIP and I will add more backends like MusicBrainz once I know that this is the way to go about it.~~
MusicBrainz uses coverartarchive.org as backend which is terrible. Last.fm has a much richer database and I'm sure if Last.fm doesn't have the album art, MusicBrainz won't have it too.

~~Additionally, I'm not sure whether to delete the downloaded images after they have been embedded to the mp3, so I've kept them for now.~~

An additional command line argument for specifying the search terms as a string has also been provided