### PR TITLE
Open CSV the Python 3 way

### DIFF
--- a/download_spotify_playlist/download.py
+++ b/download_spotify_playlist/download.py
@@ -12,7 +12,7 @@ from unidecode import unidecode
 
 def get_songs_from_csvfile(csvfile, args):
     songs = []
-    with open(csvfile, 'rb') as csvfile:
+    with open(csvfile, 'r') as csvfile:
         reader = csv.reader(csvfile)
         next(reader)  # Skip the first line
         if args.skip:


### PR DESCRIPTION
With this PR we open the CSV as 'r' rather than 'rb'

Fixes #17 